### PR TITLE
fix values too large overflow error

### DIFF
--- a/pysz/sz.pxd
+++ b/pysz/sz.pxd
@@ -35,3 +35,5 @@ cdef extern from "SZ3/api/sz.hpp":
 cdef extern from "SZ3/utils/Statistic.hpp" namespace "SZ3":
     void verify[Type](Type *ori_data, Type *data, size_t num_elements)
 
+cdef extern from "stdint.h":
+    ctypedef unsigned char uint8_t

--- a/pysz/sz.pyx
+++ b/pysz/sz.pyx
@@ -256,7 +256,7 @@ cdef class sz:
         if len(args) == 1 and args[0] == '-d':
             this.inBytesPtr = malloc(array.size)
             for i in range(array.size):
-                (<char*>this.inBytesPtr)[i] = array[i]
+                (<uint8_t*>this.inBytesPtr)[i] = array[i]
             this.cmpSize = array.size
             return
         elif len(args) > 0:


### PR DESCRIPTION
Fix OverflowError: value too large to convert to char , when decompressing from nd array